### PR TITLE
Fix typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,7 @@ impl<B: HashBytes> ImageHash<B> {
     /// Create an `ImageHash` instance from the given Base64-encoded string.
     ///
     /// ## Errors:
-    /// Returns `InvalidBytesError::Base64(DecodeError::InvalidLength)` if the string wasn't valid base64`.
+    /// Returns `InvalidBytesError::Base64(DecodeError::InvalidLength)` if the string wasn't valid base64.
     /// Otherwise returns the same errors as `from_bytes`.
     pub fn from_base64(encoded_hash: &str) -> Result<ImageHash<B>, InvalidBytesError> {
         let bytes = base64::decode(encoded_hash).map_err(InvalidBytesError::Base64)?;


### PR DESCRIPTION
Found a backslash that causes documentation to be rendered incorrectly:

![图片](https://user-images.githubusercontent.com/95505675/208320171-b413d451-a25c-4aee-8ab8-c03a28c84dda.png)
