### PR TITLE
Update base64 to 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 nightly = []
 
 [dependencies]
-base64 = "0.13.1"
+base64 = "0.21.0"
 image = { version = ">=0.24,<0.25", default-features = false }
 rustdct = "0.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! let hash1 = hasher.hash_image(&image1);
 //! let hash2 = hasher.hash_image(&image2);
-//!     
+//!
 //! println!("Image1 hash: {}", hash1.to_base64());
 //! println!("Image2 hash: {}", hash2.to_base64());
 //!
@@ -29,6 +29,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::marker::PhantomData;
 
+use base64::Engine;
 use image::imageops;
 pub use image::imageops::FilterType;
 use image::GrayImage;
@@ -482,7 +483,9 @@ impl<B: HashBytes> ImageHash<B> {
     /// Returns `InvalidBytesError::Base64(DecodeError::InvalidLength)` if the string wasn't valid base64.
     /// Otherwise returns the same errors as `from_bytes`.
     pub fn from_base64(encoded_hash: &str) -> Result<ImageHash<B>, InvalidBytesError> {
-        let bytes = base64::decode(encoded_hash).map_err(InvalidBytesError::Base64)?;
+        let bytes = base64::engine::general_purpose::STANDARD_NO_PAD
+            .decode(encoded_hash)
+            .map_err(InvalidBytesError::Base64)?;
 
         Self::from_bytes(&bytes)
     }
@@ -491,7 +494,7 @@ impl<B: HashBytes> ImageHash<B> {
     ///
     /// Mostly for printing convenience.
     pub fn to_base64(&self) -> String {
-        base64::encode(self.hash.as_slice())
+        base64::engine::general_purpose::STANDARD_NO_PAD.encode(self.hash.as_slice())
     }
 }
 


### PR DESCRIPTION
Updated the `base64` crate to verion 0.21.0, using the `STANDARD_NO_PAD` encoder