### PR TITLE
fix(clippy): Unnecessary deref

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,7 +536,7 @@ mod test {
             buf.set_len(len);
         } // We immediately fill the buffer.
         let mut rng = SmallRng::seed_from_u64(0xc0ffee);
-        rng.fill_bytes(&mut *buf);
+        rng.fill_bytes(&mut buf);
 
         ImageBuffer::from_raw(width, height, buf).unwrap()
     }


### PR DESCRIPTION
There is an unecessary deref in the tests, which clippy was warning me about.

Clippy also warns about the `let vec = Vec::with_capacity(len); unsafe {vec.set_length(len)};`, although it is 'sound', the compiler might break the code, using `let vec = vec![0; len];` is safe but slower, is that a worthy tradeof?